### PR TITLE
fix: enforce IPv4 for MongoDB connection and update CORS origins

### DIFF
--- a/config/db.js
+++ b/config/db.js
@@ -19,6 +19,7 @@ export async function connectToDatabase() {
 		const opts = {
 			bufferCommands: false,
 			maxPoolSize: 10,
+			family: 4,
 		};
 
 		cached.promise = mongoose.connect(process.env.MONGO_URI, opts).then((mongoose) => {

--- a/index.js
+++ b/index.js
@@ -19,7 +19,11 @@ const app = Fastify({
 
 // CORS registration
 await app.register(cors, {
-	origin: ["https://quiz-time-with-react.vercel.app", "http://localhost:5173"],
+	origin: [
+		"https://quiz-time-with-react.vercel.app",
+		"http://localhost:5173",
+		"http://127.0.0.1:5173",
+	],
 	methods: ["GET", "POST", "PUT", "DELETE", "OPTIONS"],
 	allowedHeaders: ["Content-Type", "Authorization"],
 	credentials: true,


### PR DESCRIPTION
## Summary
Fixed connection timeouts in environments like GitHub Codespaces by enforcing IPv4 usage for MongoDB. Also updated CORS configuration to allow local frontend development.

## Changes
- Updated `mongoose.connect` options to include `family: 4`, which forces IPv4 usage and resolves DNS issues in some containerized environments.
- Added `http://127.0.0.1:5173` to the allowed CORS origins list to support Vite's default local development server.

## How to Test
1. Run the backend server in a Codespace or local environment where IPv6 might be prioritized.
2. Verify that the database connection is established successfully without timeout errors.
3. Start the frontend locally at `http://127.0.0.1:5173` and confirm that API requests are not blocked by CORS.