### PR TITLE
fix: ensure final random nickname is strictly unique

### DIFF
--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -123,9 +123,9 @@ export const getNicknameArray = async (request, reply) => {
 		while (!isUnique) {
 			const lastNickname = iterator.next().value;
 			const isTaken = await User.exists({ nickname: lastNickname });
+			nicknameArray.push(lastNickname);
 
 			if (!isTaken) {
-				nicknameArray.push(lastNickname);
 				isUnique = true;
 			}
 		}

--- a/utils/nicknameGen.js
+++ b/utils/nicknameGen.js
@@ -3,8 +3,8 @@ const nouns = ["Lion", "Eagle", "Shark", "Wolf", "Panther", "Falcon", "Tiger", "
 export function* generateNickname() {
     while (true) {
         const id = Math.floor(Math.random() * 9999);
-        const adjective = adjectives[Math.floor(Math.random() * 7)];
-        const noun = nouns[Math.floor(Math.random() * 7)];
+        const adjective = adjectives[Math.floor(Math.random() * (adjectives.length))];
+        const noun = nouns[Math.floor(Math.random() * (nouns.length))];
         const nickname = adjective + noun + "#" + id;
         yield nickname;
     }


### PR DESCRIPTION
Resolves an issue where randomly generated nicknames could occasionally duplicate existing ones. Added a strict uniqueness check to guarantee the final assigned nickname is one-of-a-kind.