### PR TITLE
feat: implement global quiz sorting with ukrainian collation

### DIFF
--- a/controllers/quizController.js
+++ b/controllers/quizController.js
@@ -42,8 +42,8 @@ export const getAllQuizzes = async (request, reply) => {
 
 		let sortQuery = { _id: -1 };
 		if (sortParam === "oldest") sortQuery = { _id: 1 };
-		else if (sortParam === "az") sortQuery = { title: 1 };
-		else if (sortParam === "za") sortQuery = { title: -1 };
+		else if (sortParam === "az") sortQuery = { title: 1, _id: 1 };
+		else if (sortParam === "za") sortQuery = { title: -1, _id: -1 };
 
 		const quizzes = await Quiz.find(filter)
 			.collation({ locale: "uk", strength: 2 })


### PR DESCRIPTION
## Summary
Added global sorting capabilities to the quiz feed. Users can now sort quizzes by date (newest/oldest) and alphabetically (A-Z/Z-A). Implemented advanced MongoDB collation to ensure case-insensitive sorting that properly supports both English and Ukrainian alphabets.

## Changes
- Updated the `getAllQuizzes` controller to accept a new `sort` query parameter (`newest`, `oldest`, `az`, `za`).
- Implemented default fallback sorting (newest first) to prevent invalid queries.
- Added `.collation({ locale: "uk", strength: 2 })` to the Mongoose query to ensure accurate alphabetical ordering regardless of letter case.
- Verified that sorting works seamlessly alongside existing pagination, search filters, and author population.