### PR TITLE
Add filtering by author ID feature

### DIFF
--- a/controllers/quizController.js
+++ b/controllers/quizController.js
@@ -33,17 +33,11 @@ export const getAllQuizzes = async (request, reply) => {
 		const authorId = request.query.authorId || "";
 
 		let filter = {};
-		if (search && authorId) {
-			filter = {
-				$and: [
-					{ title: { $regex: search, $options: "i" } },
-					{ authorId: authorId }
-				]
-			};
-		} else if (search) {
-			filter = { title: { $regex: search, $options: "i" } };
-		} else if (authorId) {
-			filter = { authorId: authorId };
+		if (search) {
+			filter.title = { $regex: search, $options: "i" };
+		}
+		if (authorId) {
+			filter.authorId = authorId;
 		}
 
 		let sortQuery = { createdAt: -1 };

--- a/controllers/quizController.js
+++ b/controllers/quizController.js
@@ -30,15 +30,17 @@ export const getAllQuizzes = async (request, reply) => {
 
 		const search = request.query.search || "";
 		const sortParam = request.query.sort || "newest";
+		const authorId = request.query.authorId || "";
 
-		const filter = search
-			? {
-					$or: [
-						{ title: { $regex: search, $options: "i" } },
-						{ description: { $regex: search, $options: "i" } },
-					],
-				}
-			: {};
+		let filter = {};
+		if (search || authorId) {
+			filter = {
+				$and: [
+					{title: { $regex: search, $options: "i" }},
+					{authorId: authorId}
+				]
+			}
+		}
 
 		let sortQuery = { createdAt: -1 };
 		if (sortParam === "oldest") sortQuery = { createdAt: 1 };

--- a/controllers/quizController.js
+++ b/controllers/quizController.js
@@ -33,13 +33,17 @@ export const getAllQuizzes = async (request, reply) => {
 		const authorId = request.query.authorId || "";
 
 		let filter = {};
-		if (search || authorId) {
+		if (search && authorId) {
 			filter = {
 				$and: [
-					{title: { $regex: search, $options: "i" }},
-					{authorId: authorId}
+					{ title: { $regex: search, $options: "i" } },
+					{ authorId: authorId }
 				]
-			}
+			};
+		} else if (search) {
+			filter = { title: { $regex: search, $options: "i" } };
+		} else if (authorId) {
+			filter = { authorId: authorId };
 		}
 
 		let sortQuery = { createdAt: -1 };


### PR DESCRIPTION
## Summary
Updated the backend filter logic to support filtering quizzes by author. The search condition was modified to use an `$and` operator, requiring matches for both `title` and `authorId`, and the text search was restricted to titles only.

## Changes
- Added extraction of `authorId` from `request.query`.
- Replaced the `$or` filter condition (which previously searched both `title` and `description`) with an `$and` condition.
- Updated the query filter to strictly apply the regex search to the `title` field and an exact match to the `authorId` field.

## Linked Issue
Closes #1

## How to Test
1. Make an API request to the endpoint with an `authorId` query parameter and verify that only results belonging to that author are returned.
2. Make a request with a `search` query parameter and verify it now searches only within the `title` (ignoring the `description`).
3. Make a request providing both `search` and `authorId` parameters to ensure the `$and` logic works correctly.